### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.txt

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@
 import io
 from setuptools import setup, find_packages
 
-with open("../README.md", "r") as fh:
+with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
@@ -43,7 +43,7 @@ setup(
     license="GPLv3",
     keywords="pyxel",
     url="https://github.com/Qiufeng54321/muser",
-    install_requires=io.open("../requirements.txt", "r").read().split("\n"),
+    install_requires=io.open("requirements.txt", "r").read().split("\n"),
     packages=find_packages(),
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
Include missing files in sdist for #1

Tested with

```
+++ mktemp -d
++ D=/tmp/tmp.QsPRr8i6cI
++ trap 'rm -rf /tmp/tmp.QsPRr8i6cI' EXIT
++ python -m venv /tmp/tmp.QsPRr8i6cI
++ python setup.py sdist -d /tmp/tmp.QsPRr8i6cI
running sdist
running egg_info
writing muser.egg-info/PKG-INFO
writing dependency_links to muser.egg-info/dependency_links.txt
writing entry points to muser.egg-info/entry_points.txt
writing requirements to muser.egg-info/requires.txt
writing top-level names to muser.egg-info/top_level.txt
reading manifest file 'muser.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'muser.egg-info/SOURCES.txt'
running check
creating muser-1.2.2
creating muser-1.2.2/muser
creating muser-1.2.2/muser.egg-info
creating muser-1.2.2/muser/game
creating muser-1.2.2/muser/game/playthrough
creating muser-1.2.2/muser/sheet
creating muser-1.2.2/muser/sheet/gen
creating muser-1.2.2/muser/sheet/reader
copying files to muser-1.2.2...
copying MANIFEST.in -> muser-1.2.2
copying README.md -> muser-1.2.2
copying requirements.txt -> muser-1.2.2
copying setup.py -> muser-1.2.2
copying muser/__init__.py -> muser-1.2.2/muser
copying muser/assets.py -> muser-1.2.2/muser
copying muser/frame2image.py -> muser-1.2.2/muser
copying muser/game_config.py -> muser-1.2.2/muser
copying muser/image2pyxres.py -> muser-1.2.2/muser
copying muser/main.py -> muser-1.2.2/muser
copying muser/meta2sheet.py -> muser-1.2.2/muser
copying muser/muser_main.py -> muser-1.2.2/muser
copying muser/profile.py -> muser-1.2.2/muser
copying muser/pyxres2frame.py -> muser-1.2.2/muser
copying muser/pyxres2image.py -> muser-1.2.2/muser
copying muser/util.py -> muser-1.2.2/muser
copying muser.egg-info/PKG-INFO -> muser-1.2.2/muser.egg-info
copying muser.egg-info/SOURCES.txt -> muser-1.2.2/muser.egg-info
copying muser.egg-info/dependency_links.txt -> muser-1.2.2/muser.egg-info
copying muser.egg-info/entry_points.txt -> muser-1.2.2/muser.egg-info
copying muser.egg-info/not-zip-safe -> muser-1.2.2/muser.egg-info
copying muser.egg-info/requires.txt -> muser-1.2.2/muser.egg-info
copying muser.egg-info/top_level.txt -> muser-1.2.2/muser.egg-info
copying muser/game/__init__.py -> muser-1.2.2/muser/game
copying muser/game/casts.py -> muser-1.2.2/muser/game
copying muser/game/config.py -> muser-1.2.2/muser/game
copying muser/game/constants.py -> muser-1.2.2/muser/game
copying muser/game/frames.py -> muser-1.2.2/muser/game
copying muser/game/muser.py -> muser-1.2.2/muser/game
copying muser/game/sounds.py -> muser-1.2.2/muser/game
copying muser/game/ui.py -> muser-1.2.2/muser/game
copying muser/game/widgets.py -> muser-1.2.2/muser/game
copying muser/game/playthrough/__init__.py -> muser-1.2.2/muser/game/playthrough
copying muser/game/playthrough/base_note.py -> muser-1.2.2/muser/game/playthrough
copying muser/game/playthrough/fancy_note.py -> muser-1.2.2/muser/game/playthrough
copying muser/game/playthrough/manager_actions.py -> muser-1.2.2/muser/game/playthrough
copying muser/game/playthrough/note.py -> muser-1.2.2/muser/game/playthrough
copying muser/game/playthrough/note_manager.py -> muser-1.2.2/muser/game/playthrough
copying muser/sheet/__init__.py -> muser-1.2.2/muser/sheet
copying muser/sheet/actions.py -> muser-1.2.2/muser/sheet
copying muser/sheet/note.py -> muser-1.2.2/muser/sheet
copying muser/sheet/sheet_constants.py -> muser-1.2.2/muser/sheet
copying muser/sheet/gen/__init__.py -> muser-1.2.2/muser/sheet/gen
copying muser/sheet/gen/abs_output.py -> muser-1.2.2/muser/sheet/gen
copying muser/sheet/gen/effector.py -> muser-1.2.2/muser/sheet/gen
copying muser/sheet/gen/generator.py -> muser-1.2.2/muser/sheet/gen
copying muser/sheet/gen/meta_input.py -> muser-1.2.2/muser/sheet/gen
copying muser/sheet/gen/midi_converter.py -> muser-1.2.2/muser/sheet/gen
copying muser/sheet/gen/rel_input.py -> muser-1.2.2/muser/sheet/gen
copying muser/sheet/gen/sheet_output.py -> muser-1.2.2/muser/sheet/gen
copying muser/sheet/reader/__init__.py -> muser-1.2.2/muser/sheet/reader
copying muser/sheet/reader/sheet_reader.py -> muser-1.2.2/muser/sheet/reader
Writing muser-1.2.2/setup.cfg
Creating tar archive
removing 'muser-1.2.2' (and everything under it)
++ cd /
++ /tmp/tmp.QsPRr8i6cI/bin/pip install /tmp/tmp.QsPRr8i6cI/muser-1.2.2.tar.gz
Processing /tmp/tmp.QsPRr8i6cI/muser-1.2.2.tar.gz
Collecting pygame>=1.9.6 (from muser==1.2.2)
  Using cached https://files.pythonhosted.org/packages/0f/9c/78626be04e193c0624842090fe5555b3805c050dfaa81c8094d6441db2be/pygame-1.9.6.tar.gz
    ERROR: Command errored out with exit status 1:
     command: /tmp/tmp.QsPRr8i6cI/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-p621y8b3/pygame/setup.py'"'"'; __file__='"'"'/tmp/pip-install-p621y8b3/pygame/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base pip-egg-info
         cwd: /tmp/pip-install-p621y8b3/pygame/
    Complete output (18 lines):
    
    
    WARNING, No "Setup" File Exists, Running "buildconfig/config.py"
    Using UNIX configuration...
    
    
    Hunting dependencies...
    SDL     : found 1.2.15
    FONT    : not found
    IMAGE   : found
    MIXER   : not found
    PNG     : found
    JPEG    : found
    SCRAP   : found
    PORTMIDI: not found
    PORTTIME: not found
    FREETYPE: found 23.1.17
    Missing dependencies
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+++ rm -rf /tmp/tmp.QsPRr8i6cI
```
